### PR TITLE
Flip the catalog installation to the openwhisk-catalog repo

### DIFF
--- a/tests/dat/actions/cat.js
+++ b/tests/dat/actions/cat.js
@@ -1,0 +1,13 @@
+/**
+ * Equivalent to unix cat command.
+ * Return all the lines in an array. All other fields in the input message are stripped.
+ * @param lines An array of strings.
+ */
+function main(msg) {
+    var lines = msg.lines || [];
+    var retn = {lines: lines, payload: lines.join("\n")};
+    console.log('cat: returning ' + JSON.stringify(retn));
+    return retn;
+}
+
+

--- a/tests/dat/actions/head.js
+++ b/tests/dat/actions/head.js
@@ -1,0 +1,14 @@
+/**
+ * Return the first num lines of an array.
+ * @param lines An array of strings.
+ * @param num Number of lines to return.
+ */
+function main(msg) {
+    var lines = msg.lines || [];
+    var num = msg.num || 1;
+    var head = lines.slice(0, num);
+    console.log('head get first ' + num + ' lines of ' + lines + ': ' + head);
+    return {lines: head, num: num};
+}
+
+

--- a/tests/dat/actions/hello.js
+++ b/tests/dat/actions/hello.js
@@ -1,0 +1,6 @@
+/**
+ * Hello, world.
+ */
+function main(params) {
+    console.log('hello', params.payload+'!');
+}

--- a/tests/dat/actions/sort.js
+++ b/tests/dat/actions/sort.js
@@ -1,0 +1,14 @@
+/**
+ * Sort a set of lines.
+ * @param lines An array of strings to sort.
+ */
+function main(msg) {
+    var lines = msg.lines || [];
+    //console.log('sort got ' + lines.length + ' lines');
+    console.log('sort input msg: ' + JSON.stringify(msg));
+    console.log('sort before: ' + lines);
+    lines.sort();
+    console.log('sort after: ' + lines);
+    return {lines: lines, length: lines.length};
+}
+

--- a/tests/dat/actions/split.js
+++ b/tests/dat/actions/split.js
@@ -1,0 +1,14 @@
+/**
+ * Splits a string into an array of strings
+ * Return lines in an array.
+ * @param payload A string.
+ * @param separator The character, or the regular expression, to use for splitting the string
+ */
+function main(msg) {
+    var separator = msg.separator || /\r?\n/;
+    var payload = msg.payload.toString();
+    var lines = payload.split(separator);
+    var retn = {lines: lines, payload: msg.payload};
+    console.log('split: returning ' + JSON.stringify(retn));
+    return retn;
+}

--- a/tests/dat/actions/wordcount.js
+++ b/tests/dat/actions/wordcount.js
@@ -1,0 +1,10 @@
+/**
+ *  word count utility
+ */
+function main(params) {
+    var str = params.payload.toString();
+    var words = str.split(" ");
+    var count = words.length;
+    console.log("The message '"+str+"' has", count, 'words');
+    return { count: count };
+}

--- a/tests/src/system/basic/WskActionSequenceTests.scala
+++ b/tests/src/system/basic/WskActionSequenceTests.scala
@@ -45,23 +45,25 @@ class WskActionSequenceTests
     with WskTestHelpers {
 
     implicit val wskprops = WskProps()
-    val wsk = new Wsk(usePythonCLI = false)
-    val defaultAction = Some(TestUtils.getCatalogFilename("samples/hello.js"))
+    val wsk = new Wsk(usePythonCLI = true)
     val allowedActionDuration = 120 seconds
 
     behavior of "Wsk Action Sequence"
 
     it should "invoke a blocking action and get only the result" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
-            val pkgname = "my package"
-            val name = "sequence action"
+            val name = "sequence"
 
-            assetHelper.withCleaner(wsk.pkg, pkgname) {
-                (pkg, _) => pkg.bind("/whisk.system/util", pkgname)
+            val actions = Seq("split", "sort", "head", "cat")
+            for (actionName <- actions) {
+                val file = TestUtils.getTestActionFilename(s"$actionName.js")
+                assetHelper.withCleaner(wsk.action, actionName) { (action, _) =>
+                    action.create(name = actionName, artifact = Some(file))
+                }
             }
 
             assetHelper.withCleaner(wsk.action, name) {
-                val sequence = Seq("split", "sort", "head", "cat") map { a => s"$pkgname/$a" } mkString (",")
+                val sequence = actions.mkString (",")
                 (action, _) => action.create(name, Some(sequence), kind = Some("sequence"), timeout = Some(allowedActionDuration))
             }
 
@@ -78,7 +80,7 @@ class WskActionSequenceTests
             }
 
             // update action sequence
-            val newSequence = Seq("split", "sort") map { a => s"$pkgname/$a" } mkString (",")
+            val newSequence = Seq("split", "sort").mkString (",")
             wsk.action.create(name, Some(newSequence), kind = Some("sequence"), timeout = Some(allowedActionDuration), update = true)
             val secondrun = wsk.action.invoke(name, Map("payload" -> args.mkString("\n").toJson))
             withActivation(wsk.activation, secondrun, totalWait = allowedActionDuration) {

--- a/tests/src/system/basic/WskBasicTests.scala
+++ b/tests/src/system/basic/WskBasicTests.scala
@@ -55,7 +55,7 @@ class WskBasicTests
 
     implicit val wskprops = WskProps()
     val wsk = new Wsk(usePythonCLI = false)
-    val defaultAction = Some(TestUtils.getCatalogFilename("samples/hello.js"))
+    val defaultAction = Some(TestUtils.getTestActionFilename("hello.js"))
 
     behavior of "Wsk CLI"
 
@@ -101,43 +101,11 @@ class WskBasicTests
             stderr should include(errormsg)
     }
 
-    it should "reject deleting action in shared package not owned by authkey" in {
-        wsk.action.get("/whisk.system/util/cat") // make sure it exists
-        wsk.action.delete("/whisk.system/util/cat", expectedExitCode = FORBIDDEN)
-    }
-
-    it should "reject create action in shared package not owned by authkey" in {
-        wsk.action.get("/whisk.system/util/notallowed", expectedExitCode = NOT_FOUND) // make sure it does not exist
-        val file = Some(TestUtils.getCatalogFilename("samples/hello.js"))
-        try {
-            wsk.action.create("/whisk.system/util/notallowed", file, expectedExitCode = FORBIDDEN)
-        } finally {
-            wsk.action.sanitize("/whisk.system/util/notallowed")
-        }
-    }
-
-    it should "reject update action in shared package not owned by authkey" in {
-        wsk.action.create("/whisk.system/util/cat", None,
-            update = true, shared = Some(true), expectedExitCode = FORBIDDEN)
-    }
-
     behavior of "Wsk Package CLI"
-
-    it should "list shared packages" in {
-        val result = wsk.pkg.list(Some("/whisk.system")).stdout
-        result should include regex ("""/whisk.system/samples\s+shared""")
-        result should include regex ("""/whisk.system/util\s+shared""")
-    }
-
-    it should "list shared package actions" in {
-        val result = wsk.action.list(Some("/whisk.system/util")).stdout
-        result should include regex ("""/whisk.system/util/head\s+shared""")
-        result should include regex ("""/whisk.system/util/date\s+shared""")
-    }
 
     it should "create, update, get and list a package" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
-            val name = "samplePackage"
+            val name = "testPackage"
             val params = Map("a" -> "A".toJson)
             assetHelper.withCleaner(wsk.pkg, name) {
                 (pkg, _) =>
@@ -152,22 +120,6 @@ class WskBasicTests
             wsk.pkg.list().stdout should include(name)
     }
 
-    it should "create a package binding" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "bindPackage"
-            val provider = "/whisk.system/samples"
-            val annotations = Map("a" -> "A".toJson, WhiskPackage.bindingFieldName -> "xxx".toJson)
-            assetHelper.withCleaner(wsk.pkg, name) {
-                (pkg, _) =>
-                    pkg.bind(provider, name, annotations = annotations)
-            }
-            val stdout = wsk.pkg.get(name).stdout
-            stdout should include regex (""""key": "a"""")
-            stdout should include regex (""""value": "A"""")
-            stdout should include regex (s""""key": "${WhiskPackage.bindingFieldName}"""")
-            stdout should not include regex(""""key": "xxx"""")
-    }
-
     behavior of "Wsk Action CLI"
 
     it should "create the same action twice with different cases" in withAssetCleaner(wskprops) {
@@ -179,7 +131,7 @@ class WskBasicTests
     it should "create an action, then update its kind" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
             val name = "createAndUpdate"
-            val file = Some(TestUtils.getCatalogFilename("samples/hello.js"))
+            val file = Some(TestUtils.getTestActionFilename("hello.js"))
 
             assetHelper.withCleaner(wsk.action, name) {
                 (action, _) => action.create(name, file, kind = Some("nodejs"))
@@ -196,7 +148,7 @@ class WskBasicTests
     it should "create, update, get and list an action" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
             val name = "createAndUpdate"
-            val file = Some(TestUtils.getCatalogFilename("samples/hello.js"))
+            val file = Some(TestUtils.getTestActionFilename("hello.js"))
             val params = Map("a" -> "A".toJson)
             assetHelper.withCleaner(wsk.action, name) {
                 (action, _) =>
@@ -211,11 +163,6 @@ class WskBasicTests
             stdout should include regex (""""publish": true""")
             stdout should include regex (""""version": "0.0.2"""")
             wsk.action.list().stdout should include(name)
-    }
-
-    it should "get an action" in {
-        wsk.action.get("/whisk.system/samples/wordCount").
-            stdout should include("words")
     }
 
     it should "reject delete of action that does not exist" in {
@@ -282,7 +229,7 @@ class WskBasicTests
         (wp, assetHelper) =>
             val name = "basicInvoke"
             assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(TestUtils.getCatalogFilename("samples/wc.js")))
+                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("wordcount.js")))
             }
             wsk.action.invoke(name, Map("payload" -> "one two three".toJson), blocking = true, result = true)
                 .stdout should include regex (""""count": 3""")
@@ -314,24 +261,6 @@ class WskBasicTests
             }
 
             wsk.trigger.list().stdout should include(name)
-    }
-
-    it should "not create a trigger when feed fails to initialize" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            assetHelper.withCleaner(wsk.trigger, "badfeed", confirmDelete = false) {
-                (trigger, name) =>
-                    trigger.create(name, feed = Some(s"bogus"), expectedExitCode = ANY_ERROR_EXIT).
-                        exitCode should { equal(NOT_FOUND) or equal(FORBIDDEN) }
-                    trigger.get(name, expectedExitCode = NOT_FOUND)
-
-                    trigger.create(name, feed = Some(s"bogus/feed"), expectedExitCode = ANY_ERROR_EXIT).
-                        exitCode should { equal(NOT_FOUND) or equal(FORBIDDEN) }
-                    trigger.get(name, expectedExitCode = NOT_FOUND)
-
-                    // verify that the feed runs and returns an application error (502 or Gateway Timeout)
-                    trigger.create(name, feed = Some(s"/whisk.system/github/webhook"), expectedExitCode = TIMEOUT)
-                    trigger.get(name, expectedExitCode = NOT_FOUND)
-            }
     }
 
     it should "display a trigger summary when --summary flag is used with 'wsk trigger get'" in withAssetCleaner(wskprops) {

--- a/tests/src/whisk/core/cli/test/WskCoreBasicTests.scala
+++ b/tests/src/whisk/core/cli/test/WskCoreBasicTests.scala
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.cli.test
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.BeforeAndAfterAll
+
+import common.RunWskAdminCmd
+import common.TestHelpers
+import common.TestUtils
+import common.TestUtils.ANY_ERROR_EXIT
+import common.TestUtils.FORBIDDEN
+import common.TestUtils.NOT_FOUND
+import common.TestUtils.TIMEOUT
+import common.Wsk
+import common.WskProps
+import common.WskTestHelpers
+import spray.json.DefaultJsonProtocol._
+import spray.json.pimpAny
+import whisk.core.entity.Subject
+import whisk.core.entity.WhiskPackage
+
+@RunWith(classOf[JUnitRunner])
+class WskCoreBasicTests
+    extends TestHelpers
+    with WskTestHelpers
+    with BeforeAndAfterAll {
+
+    val originWskProps = WskProps()
+    val wsk = new Wsk(usePythonCLI = false)
+    val samplePackage = "samplePackage"
+    val sampleAction = s"$samplePackage/sampleAction"
+    val sampleFeed = s"$samplePackage/sampleFeed"
+    val wskadmin = new RunWskAdminCmd {}
+
+    val otherNamespace = Subject().toString()
+    val create = wskadmin.cli(Seq("user", "create", otherNamespace))
+    val otherAuthkey = create.stdout.trim
+    implicit val otherWskProps = WskProps(namespace = otherNamespace, authKey = otherAuthkey)
+
+    override def afterAll() = {
+        withClue(s"failed to delete temporary namespace $otherNamespace") {
+            wskadmin.cli(Seq("user", "delete", otherNamespace)).stdout should include("Subject deleted")
+        }
+    }
+
+    behavior of "Wsk CLI"
+
+    it should "reject deleting action in shared package not owned by authkey" in withAssetCleaner(otherWskProps) {
+        (wp, assetHelper) =>
+            assetHelper.withCleaner(wsk.pkg, samplePackage) {
+                (pkg, _) =>
+                    pkg.create(samplePackage, parameters = Map("a" -> "A".toJson), shared = Some(true),
+                               update = true)
+            }
+            assetHelper.withCleaner(wsk.action, sampleAction) {
+                val file = Some(TestUtils.getTestActionFilename("empty.js"))
+                (action, _) => action.create(sampleAction, file, kind = Some("nodejs"), shared = Some(true))
+            }
+            val fullyQualifiedActionName = "/" + otherNamespace + "/" + sampleAction
+            wsk.action.get(fullyQualifiedActionName)(originWskProps)
+            wsk.action.delete(fullyQualifiedActionName, expectedExitCode = FORBIDDEN)(originWskProps)
+    }
+
+    it should "reject create action in shared package not owned by authkey" in withAssetCleaner(otherWskProps) {
+        (wp, assetHelper) =>
+            assetHelper.withCleaner(wsk.pkg, samplePackage) {
+                (pkg, name) => pkg.create(name, shared = Some(true))
+            }
+            val fullyQualifiedActionName = s"/$otherNamespace/notallowed"
+            val file = Some(TestUtils.getTestActionFilename("empty.js"))
+            assetHelper.withCleaner(wsk.action, fullyQualifiedActionName, confirmDelete = false) {
+                 (action, name) => action.create(name, file, expectedExitCode = FORBIDDEN)(originWskProps) 
+            }
+    }
+
+    it should "reject update action in shared package not owned by authkey" in withAssetCleaner(otherWskProps) {
+        (wp, assetHelper) =>
+            assetHelper.withCleaner(wsk.pkg, samplePackage) {
+                (pkg, _) =>
+                    pkg.create(samplePackage, parameters = Map("a" -> "A".toJson), shared = Some(true),
+                               update = true)
+            }
+            assetHelper.withCleaner(wsk.action, sampleAction) {
+                val file = Some(TestUtils.getTestActionFilename("empty.js"))
+                (action, _) => action.create(sampleAction, file, kind = Some("nodejs"), shared = Some(true))
+            }
+            val fullyQualifiedActionName = s"/$otherNamespace/notallowed"
+            wsk.action.create(fullyQualifiedActionName, None,
+                              update = true, shared = Some(true), expectedExitCode = FORBIDDEN)(originWskProps)
+    }
+
+    behavior of "Wsk Package CLI"
+
+    it should "list shared packages" in withAssetCleaner(otherWskProps) {
+        (wp, assetHelper) =>
+            assetHelper.withCleaner(wsk.pkg, samplePackage) {
+                (pkg, _) =>
+                    pkg.create(samplePackage, parameters = Map("a" -> "A".toJson), shared = Some(true),
+                               update = true)
+            }
+            val fullyQualifiedPackageName = s"/$otherNamespace/$samplePackage"
+            val result = wsk.pkg.list(Some(s"/$otherNamespace"))(originWskProps).stdout
+            result should include regex (fullyQualifiedPackageName + """\s+shared""")
+    }
+
+    it should "list shared package actions" in withAssetCleaner(otherWskProps) {
+        (wp, assetHelper) =>
+            assetHelper.withCleaner(wsk.pkg, samplePackage) {
+                (pkg, _) =>
+                    pkg.create(samplePackage, parameters = Map("a" -> "A".toJson), shared = Some(true),
+                               update = true)
+            }
+            assetHelper.withCleaner(wsk.action, sampleAction) {
+                val file = Some(TestUtils.getTestActionFilename("empty.js"))
+                (action, _) => action.create(sampleAction, file, kind = Some("nodejs"), shared = Some(true))
+            }
+            val fullyQualifiedPackageName = s"/$otherNamespace/$samplePackage"
+            val fullyQualifiedActionName = s"/$otherNamespace/$sampleAction"
+            val result = wsk.action.list(Some(fullyQualifiedPackageName))(originWskProps).stdout
+            result should include regex (fullyQualifiedActionName + """\s+shared""")
+    }
+
+    it should "create a package binding" in withAssetCleaner(otherWskProps) {
+        (wp, assetHelper) =>
+            assetHelper.withCleaner(wsk.pkg, samplePackage) {
+                (pkg, _) =>
+                    pkg.create(samplePackage, parameters = Map("a" -> "A".toJson), shared = Some(true),
+                               update = true)
+            }
+            val fullyQualifiedPackageName = s"/$otherNamespace/$samplePackage"
+            val name = "bindPackage"
+            val provider = fullyQualifiedPackageName
+            val annotations = Map("a" -> "A".toJson, WhiskPackage.bindingFieldName -> "xxx".toJson)
+            assetHelper.withCleaner(wsk.pkg, name) {
+                (pkg, _) =>
+                    pkg.bind(provider, name, annotations = annotations)
+            }
+            val stdout = wsk.pkg.get(name).stdout
+            stdout should include regex (""""key": "a"""")
+            stdout should include regex (""""value": "A"""")
+            stdout should include regex (s""""key": "${WhiskPackage.bindingFieldName}"""")
+            stdout should not include regex(""""key": "xxx"""")
+    }
+
+    behavior of "Wsk Action CLI"
+
+    it should "get an action" in withAssetCleaner(otherWskProps) {
+        (wp, assetHelper) =>
+            assetHelper.withCleaner(wsk.pkg, samplePackage) {
+                (pkg, _) =>
+                    pkg.create(samplePackage, parameters = Map("a" -> "A".toJson), shared = Some(true),
+                               update = true)
+            }
+            assetHelper.withCleaner(wsk.action, sampleAction) {
+                val file = Some(TestUtils.getTestActionFilename("empty.js"))
+                (action, _) => action.create(sampleAction, file, kind = Some("nodejs"), shared = Some(true))
+            }
+            val fullyQualifiedActionName = s"/$otherNamespace/$sampleAction"
+            val stdout = wsk.action.get(fullyQualifiedActionName)(originWskProps).stdout
+            stdout should include("name")
+            stdout should include("parameters")
+            stdout should include("limits")
+    }
+
+    behavior of "Wsk Trigger CLI"
+
+    it should "not create a trigger with timeout error when feed fails to initialize" in withAssetCleaner(otherWskProps) {
+        (wp, assetHelper) =>
+            assetHelper.withCleaner(wsk.pkg, samplePackage) {
+                (pkg, _) =>
+                    pkg.create(samplePackage, parameters = Map("a" -> "A".toJson), shared = Some(true),
+                               update = true)
+            }
+            assetHelper.withCleaner(wsk.action, sampleFeed) {
+                val file = Some(TestUtils.getTestActionFilename("empty.js"))
+                (action, _) => action.create(sampleFeed, file, kind = Some("nodejs"), shared = Some(true))
+            }
+            val fullyQualifiedFeedName = s"/$otherNamespace/$sampleFeed"
+            assetHelper.withCleaner(wsk.trigger, "badfeed", confirmDelete = false) {
+                (trigger, name) =>
+                    trigger.create(name, feed = Some(s"bogus"), expectedExitCode = ANY_ERROR_EXIT)(originWskProps).
+                        exitCode should { equal(NOT_FOUND) or equal(FORBIDDEN) }
+                    trigger.get(name, expectedExitCode = NOT_FOUND)
+
+                    trigger.create(name, feed = Some(s"bogus/feed"), expectedExitCode = ANY_ERROR_EXIT)(originWskProps).
+                        exitCode should { equal(NOT_FOUND) or equal(FORBIDDEN) }
+                    trigger.get(name, expectedExitCode = NOT_FOUND)
+                    // verify that the feed runs and returns an application error (502 or Gateway Timeout)
+                    trigger.create(name, feed = Some(fullyQualifiedFeedName), expectedExitCode = TIMEOUT)(originWskProps)
+                    trigger.get(name, expectedExitCode = NOT_FOUND)(originWskProps)
+            }
+    }
+
+}


### PR DESCRIPTION
Currently, all the actions in openwhisk-catalog have been synchronized
with the ones in openwhisk. The test coverage of actions is equal to
openwhisk. We are technically able to switch from openwhisk/catalog to the
openwhisk-catalog.

The whisk.properties template should have the system auth key, because
the cases in openwhisk need to create sample actions and packages
under whisk.system, and check the their accessibility.
